### PR TITLE
fix: use correct URL for message playback

### DIFF
--- a/apollo/manage/messages.py
+++ b/apollo/manage/messages.py
@@ -5,11 +5,11 @@ from datetime import datetime
 import sys
 from urlparse import urljoin
 
+from backports import csv
 from flask import current_app, url_for
 from flask_script import Command, Option
 import pytz
 import requests
-import unicodecsv
 
 
 class MessagePlaybackCommand(Command):
@@ -30,7 +30,7 @@ class MessagePlaybackCommand(Command):
             handle = codecs.open(msg_file, encoding='utf-8-sig')
 
         with handle:
-            reader = unicodecsv.DictReader(handle)
+            reader = csv.DictReader(handle)
             for row in reader:
                 # ignore outbound messages
                 if row['Direction'] == 'OUT':

--- a/apollo/manage/messages.py
+++ b/apollo/manage/messages.py
@@ -21,6 +21,9 @@ class MessagePlaybackCommand(Command):
     def run(self, url, msg_file):
         settings = current_app.config
 
+        view_path = url_for('messaging.kannel_view')
+        injection_url = urljoin(url, view_path)
+
         if msg_file == '-':
             handle = codecs.getreader('utf-8-sig')(sys.stdin)
         else:
@@ -44,4 +47,4 @@ class MessagePlaybackCommand(Command):
                     'timestamp': calendar.timegm(msg_time.utctimetuple())
                 }
 
-                requests.get(url, params=data)
+                requests.get(injection_url, params=data)


### PR DESCRIPTION
the playback function, prior to this, used the specified URL to inject
messages. this would require the user to know the path to the Kannel
view. this commit fixes that.