### PR TITLE
fix: use correct full URL to inject messages

### DIFF
--- a/apollo/manage/messages.py
+++ b/apollo/manage/messages.py
@@ -21,10 +21,13 @@ class MessagePlaybackCommand(Command):
     def run(self, url, msg_file):
         settings = current_app.config
 
+        view_path = url_for('messaging.kannel_view')
+        injection_url = urljoin(url, view_path)
+
         if msg_file == '-':
             handle = io.TextIOWrapper(sys.stdin.buffer, 'utf-8-sig')
         else:
-            handle = open(msg_file)
+            handle = open(msg_file, encoding='utf-8-sig')
 
         with handle:
             reader = csv.DictReader(handle)
@@ -44,4 +47,4 @@ class MessagePlaybackCommand(Command):
                     'timestamp': calendar.timegm(msg_time.utctimetuple())
                 }
 
-                requests.get(url, params=data)
+                requests.get(injection_url, params=data)


### PR DESCRIPTION
this commit fixes message playback by using the full URL to the Kannel
view instead of the passed-in URL for message injection