### PR TITLE
default filter value for quarantine status should be None

### DIFF
--- a/apollo/submissions/filters.py
+++ b/apollo/submissions/filters.py
@@ -309,7 +309,7 @@ def make_submission_list_filter(event, form):
             ('N', _('Quarantine None')),
             ('A', _('Quarantine All')),
             ('R', _('Quarantine Results'))
-        ))
+        ), default='N')
     attributes['sender_verification'] = SubmissionSenderVerificationFilter(
         choices=(
             ('', _('Sender Verification')),


### PR DESCRIPTION
This PR sets the default quarantine status to None so only records that are not quarantined are displayed by default.