### PR TITLE
fix: cancel button to navigate to referring page

### DIFF
--- a/apollo/frontend/templates/frontend/submission_edit.html
+++ b/apollo/frontend/templates/frontend/submission_edit.html
@@ -343,7 +343,7 @@
         <button type="submit" class="btn btn-info btn-lg btn-block" style= "margin-left:1em;">Save</button>
       </div>
       <div class="col-md-2">
-        <a class="btn btn-default btn-lg btn-block" style= "margin-left:0;" href="{{ url_for('submissions.submission_list', form_id=form.id) }}">Cancel</a>
+        <a class="btn btn-default btn-lg btn-block" style= "margin-left:0;" href="{{ request.environ.get('HTTP_REFERER', url_for('submissions.submission_list', form_id=form.id)) }}">Cancel</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This PR resolves #196 and makes the cancel button also return to the calling page with all query strings preserved.