### PR TITLE
updates to phone number handling

### DIFF
--- a/apollo/frontend/templates/frontend/submission_edit.html
+++ b/apollo/frontend/templates/frontend/submission_edit.html
@@ -393,7 +393,7 @@
 
     if (phone && participant) {
       $.ajax({
-        url: "{{ url_for('participants.participant_phone_verify') }}",
+        url: "{{ url_for('participants.toggle_phone_verification') }}",
         type: 'POST',
         data: {phone: phone, participant: participant, submission: submission},
         beforeSend: function (xhr, settings) {

--- a/apollo/participants/views_participants.py
+++ b/apollo/participants/views_participants.py
@@ -112,7 +112,7 @@ def participant_list(participant_set_id=0):
         message = request.form.get('message', '')
         recipients = [x for x in [participant.phone
                       if participant.phone else ''
-                      for participant in queryset_filter.qs] if x is not '']
+                      for participant in queryset_filter.qs] if x != '']
         recipients.extend(current_app.config.get('MESSAGING_CC'))
 
         if message and recipients and permissions.send_messages.can():
@@ -380,26 +380,31 @@ def participant_edit(id, participant_set_id=0):
                 participant.partner = None
 
             phone_number = phone_number_cleaner.sub('', form.phone.data)
+            # do we have a phone number like this in the database?
+            plain_phone = Phone.query.filter_by(number=phone_number).first()
+            if plain_phone is None:
+                plain_phone = Phone.create(number=phone_number)
+                plain_phone.save()
+
+            # do we have this number linked to the participant in question?
             participant_phone = ParticipantPhone.query.filter_by(
-                participant_id=participant.id).order_by(
-                ParticipantPhone.last_seen.desc()).first()
+                participant_id=participant.id, phone_id=plain_phone.id
+            ).first()
+
             if not participant_phone:
-                phone = Phone.create(number=phone_number)
-                phone.save()
+                # no, create a link
                 participant_phone = ParticipantPhone.create(
-                    participant_id=participant.id, phone_id=phone.id,
-                    verified=True)
-                participant_phone.save()
+                    participant_id=participant.id, phone_id=plain_phone.id,
+                    verified=True
+                )
             else:
-                if participant_phone.phone:
-                    participant_phone.phone.number = phone_number
-                    participant_phone.phone.save()
-                else:
-                    phone = Phone.create(number=phone_number)
-                    phone.save()
-                    participant_phone.phone = phone
+                # yes, so update the last_seen and verified attributes
+                # so this becomes the new primary number (primary is
+                # the first verified phone number when ordered by
+                # the last_seen attribute in descending order)
+                participant_phone.last_seen = utils.current_timestamp()
                 participant_phone.verified = True
-                participant_phone.save()
+            participant_phone.save()
 
             participant.password = form.password.data
             if participant_set.extra_fields:

--- a/apollo/participants/views_participants.py
+++ b/apollo/participants/views_participants.py
@@ -304,7 +304,11 @@ def participant_performance_detail(pk):
 @route(bp, '/participant/phone/verify', methods=['POST'])
 @login_required
 @permissions.edit_participant.require(403)
-def participant_phone_verify():
+def toggle_phone_verification():
+    """
+    Toggles phone verification status for a participant phone
+    and submission
+    """
     if request.is_xhr:
         contributor = request.form.get('participant')
         phone = request.form.get('phone')
@@ -315,10 +319,10 @@ def participant_phone_verify():
         phone_contact = next(filter(
             lambda p: phone == p.phone.number,
             participant.participant_phones), False)
-        phone_contact.verified = True
+        phone_contact.verified = not phone_contact.verified
         phone_contact.save()
         participant.save()
-        submission.sender_verified = True
+        submission.sender_verified = not submission.sender_verified
         submission.save()
         return 'OK'
     else:

--- a/apollo/participants/views_participants.py
+++ b/apollo/participants/views_participants.py
@@ -310,12 +310,12 @@ def toggle_phone_verification():
     and submission
     """
     if request.is_xhr:
-        contributor = request.form.get('participant')
+        participant_id = request.form.get('participant')
         phone = request.form.get('phone')
         submission_id = request.form.get('submission')
 
         submission = Submission.query.get_or_404(submission_id)
-        participant = Participant.query.get_or_404(contributor)
+        participant = Participant.query.get_or_404(participant_id)
         phone_contact = next(filter(
             lambda p: phone == p.phone.number,
             participant.participant_phones), False)


### PR DESCRIPTION
this PR makes the following changes:
- the view for verifying phone numbers now toggles between verified and not verified,
  but the UI has not been updated, only the back end code (partial fix for #311)
- when a phone number is edited, the changes only affect the specific participant
  it was changed for (see #302)
- when a phone number is edited, it is set as the primary phone number (see #301)