### PR TITLE
fix: don't translate translated strings

### DIFF
--- a/apollo/frontend/templates/frontend/message_list.html
+++ b/apollo/frontend/templates/frontend/message_list.html
@@ -72,7 +72,7 @@
         <td class="timestamp-date text-monospace" data-timestamp="{{ right_message.received|timestamp }}">{{ right_message.received.strftime('%b %d %Y') }}</td>
         <td class="timestamp-time text-monospace" data-timestamp="{{ right_message.received|timestamp }}">{{ right_message.received.strftime('%I:%M %p') }}</td>
         <td class="text-monospace">{{ right_message.recipient }}</td>
-        <td class="text-monospace">{{ _(right_message.direction.value) }}</td>
+        <td class="text-monospace">{{ right_message.direction.value }}</td>
         <td class="text-monospace" style="word-wrap:break-word">{{ right_message.text }}</td>
         <td class="text-monospace">{% if form_type %}{{ form_type.value }}{% else %}{{ _('Invalid') }}{% endif %}</td>
       {% endif %}
@@ -81,7 +81,7 @@
         <td class="timestamp-date text-monospace" data-timestamp="{{ left_message.received|timestamp }}">{{ left_message.received.strftime('%b %d %Y') }}</td>
         <td class="timestamp-time text-monospace" data-timestamp="{{ left_message.received|timestamp }}">{{ left_message.received.strftime('%I:%M %p') }}</td>
         <td class="text-monospace">{{ left_message.sender }}</td>
-        <td class="text-monospace">{{ _(left_message.direction.value) }}</td>
+        <td class="text-monospace">{{ left_message.direction.value }}</td>
         <td class="text-monospace" style="word-wrap:break-word">{{ left_message.text }}</td>
         <td class="text-monospace">{% if form_type %}{{ form_type.value }}{% else %}{{ _('Invalid') }}{% endif %}</td>
       </tr>


### PR DESCRIPTION
this commit fixes the error raised when the language is set to
other than English and the message log is viewed. the error is
raised by attempting to translate a string marked as a deferred
translated string

see: #350