### PR TITLE
fix: clear existing paths when creating paths

### DIFF
--- a/apollo/locations/models.py
+++ b/apollo/locations/models.py
@@ -33,7 +33,9 @@ class LocationSet(BaseModel):
         ).with_entities(
             LocationTypePath.ancestor_id,
             LocationTypePath.descendant_id
-        ).all()
+        ).order_by(
+            LocationTypePath.ancestor_id, LocationTypePath.descendant_id,
+            LocationTypePath.depth).all()
 
         location_types = LocationType.query.filter(
             LocationType.location_set_id == self.id)

--- a/apollo/locations/models.py
+++ b/apollo/locations/models.py
@@ -35,16 +35,8 @@ class LocationSet(BaseModel):
             LocationTypePath.descendant_id
         )
 
-        root_id = LocationTypePath.query.filter_by(
-            location_set_id=self.id
-        ).group_by(
-            LocationTypePath.ancestor_id
-        ).with_entities(
-            func.count(LocationTypePath.ancestor_id).label('ancestor_count'),
-            LocationTypePath.ancestor_id
-        ).order_by(
-            desc('ancestor_count')
-        ).first()[1]
+        root = LocationType.root(self.id)
+        root_id = root.id if root else None
 
         location_types = LocationType.query.filter(
             LocationType.location_set_id == self.id)

--- a/apollo/locations/utils.py
+++ b/apollo/locations/utils.py
@@ -46,6 +46,9 @@ def import_graph(graph, location_set, fresh_import=False):
                 flag_modified(location_type, 'name_translations')
                 location_type.save()
 
+            else:
+                return
+
         else:
             location_type = services.location_types.create(
                 is_administrative=node.get('is_administrative', False),
@@ -70,6 +73,10 @@ def import_graph(graph, location_set, fresh_import=False):
 
     # build graph for the closure table
     nx_graph.add_edges_from(edges)
+
+    # delete existing links
+    LocationTypePath.query.filter_by(location_set=location_set).delete()
+    db.session.commit()
 
     # build closure table
     path_lengths = dict(nx.all_pairs_shortest_path_length(nx_graph))


### PR DESCRIPTION
this commit works around NetworkX's failure (by design?)
to generate a proper shortest path when edges are unordered.

see: #334