### PR TITLE
switch from alpine linux to the mainstream python docker image. #392

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,9 @@
-FROM python:3.6-alpine
+FROM python:3.6
 
 LABEL maintainer="Tim Akinbo <takinbo@timbaobjects.com>"
 
-ADD requirements/prod.txt /app/requirements.txt
-RUN set -ex \
-        && apk add --no-cache --virtual .build-deps \
-            build-base \
-        && apk add --no-cache openblas-dev \
-            libffi-dev \
-            libxml2-dev \
-            libxslt-dev \
-            postgresql-dev \
-            libmagic \
-        && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/ geos-dev \
-        && pip install -r /app/requirements.txt \
-        && cd /app/ \
-        && find /usr -depth \
-            \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
-            -exec rm -rf '{}' + \
-        && runDeps="$(scanelf --needed --nobanner --recursive /usr \
-            | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
-            | sort -u \
-            | xargs -r apk info --installed \
-            | sort -u)" \
-        && apk add --virtual .python-rundeps $runDeps \
-        && apk del --purge .build-deps \
-        && rm -rf /root/.cache
 ADD . /app/
+RUN pip install --no-cache-dir -r /app/requirements/prod.txt
 RUN cd /app/ \
     && pybabel compile -d /app/apollo/translations/
 WORKDIR /app/


### PR DESCRIPTION
This PR switches the Apollo image from using the alpine linux variant of the python 3 base image to the default which is debian based. Initial decision to use alpine linux was to make compact images but the lack of glibc support has made this choice an unfavoured one.

Resolves #392 