### PR TITLE
change data source when conflicts are not tracked

### DIFF
--- a/apollo/frontend/views_dashboard.py
+++ b/apollo/frontend/views_dashboard.py
@@ -57,10 +57,16 @@ def main_dashboard(form_id=None):
     if form is not None:
         breadcrumbs.append(form.name)
 
-    query = Submission.query.filter(
+    query_args = [
         Submission.event_id == event.id,
-        Submission.form == form,
-        Submission.submission_type == 'M').join(
+        Submission.form_id == form.id
+    ]
+    if form.track_data_conflicts:
+        query_args.append(Submission.submission_type == 'M')
+    else:
+        query_args.append(Submission.submission_type == 'O')
+
+    query = Submission.query.filter(*query_args).join(
             Location,
             Submission.location_id == Location.id
         )

--- a/apollo/process_analysis/views_process.py
+++ b/apollo/process_analysis/views_process.py
@@ -102,9 +102,12 @@ def _process_analysis(event, form_id, location_id=None, tag=None):
             ])
             grouped = False
 
-        queryset = submissions.find(
-            event=event,
-            form=form, submission_type='M').filter(
+        query_kwargs = {'event': event, 'form': form}
+        if form.track_data_conflicts:
+            query_kwargs['submission_type'] = 'M'
+        else:
+            query_kwargs['submission_type'] = 'O'
+        queryset = submissions.find(**query_kwargs).filter(
                 models.Submission.location_id.in_(location_ids),
                 models.Submission.quarantine_status != 'A')
     else:

--- a/apollo/result_analysis/views_results.py
+++ b/apollo/result_analysis/views_results.py
@@ -83,10 +83,13 @@ def _voting_results(form_id, location_id=None):
     result_field_descriptions = [
         field['description'] for field in result_fields]
 
-    queryset = submissions.find(
-        form=form,
-        submission_type='M'
-    ).filter(
+    query_kwargs = {'event': event, 'form': form}
+    if form.track_data_conflicts:
+        query_kwargs['submission_type'] = 'M'
+    else:
+        query_kwargs['submission_type'] = 'O'
+
+    queryset = submissions.find(**query_kwargs).filter(
         models.Submission.verification_status != FLAG_STATUSES['rejected'][0],
         not_(models.Submission.quarantine_status.in_(['A', 'R'])))
     filter_set = filter_class(queryset, request.args)


### PR DESCRIPTION
- when conflicts are tracked, use location checklists as the data source for dashboard and data summaries
- when conflicts are not tracked, use participant checklists as the data source
- incidents are unaffected