### PR TITLE
fix: don't cast codes as integer

### DIFF
--- a/apollo/participants/views_participants.py
+++ b/apollo/participants/views_participants.py
@@ -27,7 +27,7 @@ from ..locations.models import Location
 from ..submissions.models import Submission
 from ..users.models import UserUpload
 
-from sqlalchemy import desc, func, text
+from sqlalchemy import BigInteger, desc, func, text
 
 
 phone_number_cleaner = re.compile(r'[^0-9]')
@@ -205,10 +205,10 @@ def participant_list(participant_set_id=0, view=None):
     if request.args.get('sort_by') == 'id':
         if request.args.get('sort_direction') == 'desc':
             queryset = queryset.order_by(
-                desc(models.Participant.participant_id))
+                desc(models.Participant.participant_id.cast(BigInteger)))
         else:
             queryset = queryset.order_by(
-                models.Participant.participant_id)
+                models.Participant.participant_id.cast(BigInteger))
     elif request.args.get('sort_by') in ('location_name', 'location',):
         if request.args.get('sort_direction') == 'desc':
             queryset = queryset.order_by(
@@ -251,8 +251,8 @@ def participant_list(participant_set_id=0, view=None):
                 models.ParticipantPartner.name)
     else:
         queryset = queryset.order_by(
-            models.Location.code,
-            models.Participant.participant_id)
+            models.Location.code.cast(BigInteger),
+            models.Participant.participant_id.cast(BigInteger))
 
     # request.args is immutable, so the .pop() call will fail on it.
     # using .copy() returns a mutable version of it.

--- a/apollo/participants/views_participants.py
+++ b/apollo/participants/views_participants.py
@@ -27,7 +27,7 @@ from ..locations.models import Location
 from ..submissions.models import Submission
 from ..users.models import UserUpload
 
-from sqlalchemy import desc, Integer, func, text
+from sqlalchemy import desc, func, text
 
 
 phone_number_cleaner = re.compile(r'[^0-9]')
@@ -205,10 +205,10 @@ def participant_list(participant_set_id=0, view=None):
     if request.args.get('sort_by') == 'id':
         if request.args.get('sort_direction') == 'desc':
             queryset = queryset.order_by(
-                desc(models.Participant.participant_id.cast(Integer)))
+                desc(models.Participant.participant_id))
         else:
             queryset = queryset.order_by(
-                models.Participant.participant_id.cast(Integer))
+                models.Participant.participant_id)
     elif request.args.get('sort_by') in ('location_name', 'location',):
         if request.args.get('sort_direction') == 'desc':
             queryset = queryset.order_by(
@@ -251,8 +251,8 @@ def participant_list(participant_set_id=0, view=None):
                 models.ParticipantPartner.name)
     else:
         queryset = queryset.order_by(
-            models.Location.code.cast(Integer),
-            models.Participant.participant_id.cast(Integer))
+            models.Location.code,
+            models.Participant.participant_id)
 
     # request.args is immutable, so the .pop() call will fail on it.
     # using .copy() returns a mutable version of it.

--- a/apollo/submissions/views_submissions.py
+++ b/apollo/submissions/views_submissions.py
@@ -13,7 +13,7 @@ from flask_menu import register_menu
 from flask_security import current_user, login_required
 from flask_security.utils import verify_and_update_password
 from slugify import slugify_unicode
-from sqlalchemy import desc, func, text
+from sqlalchemy import BigInteger, desc, func, text
 from sqlalchemy.dialects.postgresql import array
 from sqlalchemy.sql import false
 from tablib import Dataset
@@ -251,10 +251,10 @@ def submission_list(form_id):
     if request.args.get('sort_by') == 'id':
         if request.args.get('sort_direction') == 'desc':
             queryset = queryset.order_by(
-                desc(models.Participant.participant_id))
+                desc(models.Participant.participant_id.cast(BigInteger)))
         else:
             queryset = queryset.order_by(
-                models.Participant.participant_id)
+                models.Participant.participant_id.cast(BigInteger))
     elif request.args.get('sort_by') == 'location':
         if request.args.get('sort_direction') == 'desc':
             queryset = queryset.order_by(
@@ -276,8 +276,8 @@ def submission_list(form_id):
                 models.PhoneContact.number)
     else:
         queryset = queryset.order_by(
-            models.Location.code,
-            models.Participant.participant_id)
+            models.Location.code.cast(BigInteger),
+            models.Participant.participant_id.cast(BigInteger))
 
     query_filterset = filter_class(queryset, request.args)
     filter_form = query_filterset.form
@@ -1155,10 +1155,10 @@ def quality_assurance_list(form_id):
     if request.args.get('sort_by') == 'id':
         if request.args.get('sort_direction') == 'desc':
             queryset = queryset.order_by(
-                desc(models.Participant.participant_id))
+                desc(models.Participant.participant_id.cast(BigInteger)))
         else:
             queryset = queryset.order_by(
-                models.Participant.participant_id)
+                models.Participant.participant_id.cast(BigInte))
     elif request.args.get('sort_by') == 'location':
         if request.args.get('sort_direction') == 'desc':
             queryset = queryset.order_by(
@@ -1180,8 +1180,8 @@ def quality_assurance_list(form_id):
                 models.PhoneContact.number)
     else:
         queryset = queryset.order_by(
-            models.Location.code,
-            models.Participant.participant_id)
+            models.Location.code.cast(BigInteger),
+            models.Participant.participant_id.cast(BigInteger))
 
     if not form.quality_checks:
         queryset = models.Submission.query.filter(false())

--- a/apollo/submissions/views_submissions.py
+++ b/apollo/submissions/views_submissions.py
@@ -13,7 +13,7 @@ from flask_menu import register_menu
 from flask_security import current_user, login_required
 from flask_security.utils import verify_and_update_password
 from slugify import slugify_unicode
-from sqlalchemy import desc, Integer, func, text
+from sqlalchemy import desc, func, text
 from sqlalchemy.dialects.postgresql import array
 from sqlalchemy.sql import false
 from tablib import Dataset
@@ -251,10 +251,10 @@ def submission_list(form_id):
     if request.args.get('sort_by') == 'id':
         if request.args.get('sort_direction') == 'desc':
             queryset = queryset.order_by(
-                desc(models.Participant.participant_id.cast(Integer)))
+                desc(models.Participant.participant_id))
         else:
             queryset = queryset.order_by(
-                models.Participant.participant_id.cast(Integer))
+                models.Participant.participant_id)
     elif request.args.get('sort_by') == 'location':
         if request.args.get('sort_direction') == 'desc':
             queryset = queryset.order_by(
@@ -276,8 +276,8 @@ def submission_list(form_id):
                 models.PhoneContact.number)
     else:
         queryset = queryset.order_by(
-            models.Location.code.cast(Integer),
-            models.Participant.participant_id.cast(Integer))
+            models.Location.code,
+            models.Participant.participant_id)
 
     query_filterset = filter_class(queryset, request.args)
     filter_form = query_filterset.form
@@ -1155,10 +1155,10 @@ def quality_assurance_list(form_id):
     if request.args.get('sort_by') == 'id':
         if request.args.get('sort_direction') == 'desc':
             queryset = queryset.order_by(
-                desc(models.Participant.participant_id.cast(Integer)))
+                desc(models.Participant.participant_id))
         else:
             queryset = queryset.order_by(
-                models.Participant.participant_id.cast(Integer))
+                models.Participant.participant_id)
     elif request.args.get('sort_by') == 'location':
         if request.args.get('sort_direction') == 'desc':
             queryset = queryset.order_by(
@@ -1180,8 +1180,8 @@ def quality_assurance_list(form_id):
                 models.PhoneContact.number)
     else:
         queryset = queryset.order_by(
-            models.Location.code.cast(Integer),
-            models.Participant.participant_id.cast(Integer))
+            models.Location.code,
+            models.Participant.participant_id)
 
     if not form.quality_checks:
         queryset = models.Submission.query.filter(false())

--- a/apollo/submissions/views_submissions.py
+++ b/apollo/submissions/views_submissions.py
@@ -1158,7 +1158,7 @@ def quality_assurance_list(form_id):
                 desc(models.Participant.participant_id.cast(BigInteger)))
         else:
             queryset = queryset.order_by(
-                models.Participant.participant_id.cast(BigInte))
+                models.Participant.participant_id.cast(BigInteger))
     elif request.args.get('sort_by') == 'location':
         if request.args.get('sort_direction') == 'desc':
             queryset = queryset.order_by(


### PR DESCRIPTION
casting location/participant IDs as integer can cause strange errors,
as can be seen in the original comment on #361. this also would avoid
errors in the event that either kind of ID is not a numeric string

see: #361