### PR TITLE
fix: replace duplicate role ID

### DIFF
--- a/migrations/versions/872591ee58b4_.py
+++ b/migrations/versions/872591ee58b4_.py
@@ -498,7 +498,7 @@ def upgrade():
     SELECT nextval(pg_get_serial_sequence('role', 'id'))
     """)
     conn.execute(text("""INSERT INTO role (
-        id, deployment_id, name, uuid) VALUES (4, 1, 'field-coordinator', :uuid)"""),
+        id, deployment_id, name, uuid) VALUES (5, 1, 'field-coordinator', :uuid)"""),
                  uuid=uuid4().hex)
     op.execute("""
     SELECT nextval(pg_get_serial_sequence('role', 'id'))


### PR DESCRIPTION
fixes an error running migrations on a fresh database.