### PR TITLE
fix: use correct table names for sorting

### DIFF
--- a/apollo/locations/tasks.py
+++ b/apollo/locations/tasks.py
@@ -135,7 +135,7 @@ def update_locations(data_frame, header_mapping, location_set, task):
             reg_voters_column = header_mapping.get(reg_voters_column_key)
 
             location_names = [
-                current_row.get(col).strip() for col in name_columns
+                current_row.get(col) for col in name_columns
             ]
             location_code = current_row.get(code_column)
             if isinstance(location_code, numbers.Number):
@@ -183,8 +183,9 @@ def update_locations(data_frame, header_mapping, location_set, task):
                 'geom': geom_spec,
                 'code': location_code,
                 'name_translations': {
-                    locale: name
-                    for locale, name in zip(locales, location_names) if name
+                    locale: str(name).strip()
+                    for locale, name in zip(locales, location_names)
+                    if name and not isnull(name)
                 }
             }
 

--- a/apollo/locations/tasks.py
+++ b/apollo/locations/tasks.py
@@ -134,7 +134,9 @@ def update_locations(data_frame, header_mapping, location_set, task):
             lon_column = header_mapping.get(lon_column_key)
             reg_voters_column = header_mapping.get(reg_voters_column_key)
 
-            location_names = [current_row.get(col) for col in name_columns]
+            location_names = [
+                current_row.get(col).strip() for col in name_columns
+            ]
             location_code = current_row.get(code_column)
             if isinstance(location_code, numbers.Number):
                 location_code = str(int(location_code))

--- a/apollo/participants/tasks.py
+++ b/apollo/participants/tasks.py
@@ -168,9 +168,9 @@ def update_participants(dataframe, header_map, participant_set, task):
                 participant_set_id=participant_set.id
             )
 
-
-        participant_full_names = [record.get(col) for col in full_name_columns]
-
+        participant_full_names = [
+            record.get(col).strip() for col in full_name_columns
+        ]
         if participant_full_names:
             participant.full_name_translations = {
                 locale: name
@@ -179,8 +179,8 @@ def update_participants(dataframe, header_map, participant_set, task):
             }
 
         participant_first_names = [
-            record.get(col) for col in first_name_columns]
-
+            record.get(col).strip() for col in first_name_columns
+        ]
         if participant_first_names:
             participant.first_name_translations = {
                 locale: name
@@ -189,8 +189,8 @@ def update_participants(dataframe, header_map, participant_set, task):
             }
 
         participant_other_names = [
-            record.get(col) for col in other_names_columns]
-
+            record.get(col).strip() for col in other_names_columns
+        ]
         if participant_other_names:
             participant.other_names_translations = {
                 locale: name
@@ -198,8 +198,9 @@ def update_participants(dataframe, header_map, participant_set, task):
                 if _is_valid(name)
             }
 
-        participant_last_names = [record.get(col) for col in last_name_columns]
-
+        participant_last_names = [
+            record.get(col).strip() for col in last_name_columns
+        ]
         if participant_last_names:
             participant.last_name_translations = {
                 locale: name

--- a/apollo/participants/tasks.py
+++ b/apollo/participants/tasks.py
@@ -168,42 +168,41 @@ def update_participants(dataframe, header_map, participant_set, task):
                 participant_set_id=participant_set.id
             )
 
-        participant_full_names = [
-            record.get(col).strip() for col in full_name_columns
-        ]
+        participant_full_names = [record.get(col) for col in full_name_columns]
         if participant_full_names:
             participant.full_name_translations = {
-                locale: name
+                locale: str(name).strip()
                 for locale, name in zip(locales, participant_full_names)
                 if _is_valid(name)
             }
 
         participant_first_names = [
-            record.get(col).strip() for col in first_name_columns
+            record.get(col) for col in first_name_columns
         ]
         if participant_first_names:
             participant.first_name_translations = {
-                locale: name
+                locale: str(name).strip()
                 for locale, name in zip(locales, participant_first_names)
                 if _is_valid(name)
             }
 
         participant_other_names = [
-            record.get(col).strip() for col in other_names_columns
+            record.get(col) for col in other_names_columns
         ]
         if participant_other_names:
             participant.other_names_translations = {
-                locale: name
+                locale: str(name).strip()
                 for locale, name in zip(locales, participant_other_names)
                 if _is_valid(name)
             }
 
         participant_last_names = [
-            record.get(col).strip() for col in last_name_columns
+            record.get(col)
+            for col in last_name_columns
         ]
         if participant_last_names:
             participant.last_name_translations = {
-                locale: name
+                locale: str(name).strip()
                 for locale, name in zip(locales, participant_last_names)
                 if _is_valid(name)
             }

--- a/apollo/submissions/views_submissions.py
+++ b/apollo/submissions/views_submissions.py
@@ -316,22 +316,22 @@ def submission_list(form_id):
             queryset = queryset.order_by(text('translation.value'))
     elif request.args.get('sort_by') == 'participant':
         # specify the conditions for the order term
-        condition1 = text('full_name_translations IS NULL')
-        condition2 = text('full_name_translations IS NOT NULL')
+        condition1 = text('participant_full_name IS NULL')
+        condition2 = text('participant_full_name IS NOT NULL')
 
         # concatenation for the full name
         full_name_concat = func.concat_ws(
             ' ',
-            text('first_name_translations.value'),
-            text('other_names_translations.value'),
-            text('last_name_translations.value'),
+            text('participant_first_name.value'),
+            text('participant_other_names.value'),
+            text('participant_last_name.value'),
         ).alias('full_name_concat')
 
         # if the full name is empty, order by the concatenated
         # name, else order by the full name
         order_term = case([
             (condition1, full_name_concat),
-            (condition2, text('full_name_translations.value')),
+            (condition2, text('participant_full_name.value')),
         ])
         if request.args.get('sort_direction') == 'desc':
             queryset = queryset.order_by(
@@ -1323,22 +1323,22 @@ def quality_assurance_list(form_id):
             queryset = queryset.order_by(text('translation.value'))
     elif request.args.get('sort_by') == 'participant':
         # specify the conditions for the order term
-        condition1 = text('full_name_translations IS NULL')
-        condition2 = text('full_name_translations IS NOT NULL')
+        condition1 = text('participant_full_name IS NULL')
+        condition2 = text('participant_full_name IS NOT NULL')
 
         # concatenation for the full name
         full_name_concat = func.concat_ws(
             ' ',
-            text('first_name_translations.value'),
-            text('other_names_translations.value'),
-            text('last_name_translations.value'),
+            text('participant_first_name.value'),
+            text('participant_other_names.value'),
+            text('participant_last_name.value'),
         ).alias('full_name_concat')
 
         # if the full name is empty, order by the concatenated
         # name, else order by the full name
         order_term = case([
             (condition1, full_name_concat),
-            (condition2, text('full_name_translations.value')),
+            (condition2, text('participant_full_name.value')),
         ])
         if request.args.get('sort_direction') == 'desc':
             queryset = queryset.order_by(


### PR DESCRIPTION
- this commit fixes a bug where Apollo would crash when attempting to sort a submission list (QA  or regular) by the participant name.
- this commit further strips prepending and successive whitespace from location and participant names on import