### PR TITLE
fix: require same permissions to update conditional fields

### DIFF
--- a/apollo/submissions/forms.py
+++ b/apollo/submissions/forms.py
@@ -171,7 +171,7 @@ def make_submission_edit_form_class(event, form):
                 filters=[lambda data: data if data else ''],
                 validators=[validators.Optional()]
             )
-        if permissions.edit_submission_quarantine_status.can():
+        if permissions.edit_submission_verification_status.can():
             form_fields['verified_fields'] = fields.SelectMultipleField(
                 _('Verified'),
                 choices=[(tag, tag) for tag in form.tags],

--- a/apollo/submissions/views_submissions.py
+++ b/apollo/submissions/views_submissions.py
@@ -897,7 +897,7 @@ def submission_edit(submission_id):
                         'quarantine_status')
                     new_offline_status = submission_form.unreachable.data
 
-                    if permissions.edit_submission_quarantine_status.can():
+                    if permissions.edit_submission_verification_status.can():
                         new_verified_fields = \
                             submission_form.verified_fields.data
                         if new_verified_fields != submission.verified_fields:
@@ -905,6 +905,7 @@ def submission_edit(submission_id):
                             update_params['verified_fields'] = \
                                 new_verified_fields
 
+                    if permissions.edit_submission_quarantine_status.can():
                         if (
                             new_quarantine_status in get_valid_values(
                                 Submission.QUARANTINE_STATUSES)

--- a/apollo/submissions/views_submissions.py
+++ b/apollo/submissions/views_submissions.py
@@ -897,22 +897,25 @@ def submission_edit(submission_id):
                         'quarantine_status')
                     new_offline_status = submission_form.unreachable.data
 
-                    new_verified_fields = submission_form.verified_fields.data
-                    if new_verified_fields != submission.verified_fields:
-                        changed = True
-                        update_params['verified_fields'] = new_verified_fields
-
-                    if (
-                        new_quarantine_status in get_valid_values(
-                            Submission.QUARANTINE_STATUSES)
-                    ):
-                        if (
-                            submission.quarantine_status !=
-                            new_quarantine_status
-                        ):
+                    if permissions.edit_submission_quarantine_status.can():
+                        new_verified_fields = \
+                            submission_form.verified_fields.data
+                        if new_verified_fields != submission.verified_fields:
                             changed = True
-                        update_params['quarantine_status'] = \
-                            new_quarantine_status
+                            update_params['verified_fields'] = \
+                                new_verified_fields
+
+                        if (
+                            new_quarantine_status in get_valid_values(
+                                Submission.QUARANTINE_STATUSES)
+                        ):
+                            if (
+                                submission.quarantine_status !=
+                                new_quarantine_status
+                            ):
+                                changed = True
+                            update_params['quarantine_status'] = \
+                                new_quarantine_status
                     if (
                         new_verification_status in get_valid_values(
                             Submission.VERIFICATION_STATUSES)


### PR DESCRIPTION
some fields (`verified_fields` and `quarantine_status`, specifically)
are rendered in the submission edit only if you have a certain permission.
prior to this commit, editing submissions without that permission resulted
in a server error. this commit allows users lacking the permission to still
edit submissions without issues.

see: #623