### PR TITLE
fixed timezone conversion for use in filters with a date widget

### DIFF
--- a/apollo/messaging/filters.py
+++ b/apollo/messaging/filters.py
@@ -58,10 +58,11 @@ class DateFilter(CharFilter):
             except (OverflowError, ValueError):
                 return query.filter(False)
 
-            dt = dt.replace(tzinfo=APP_TZ).astimezone(
-                    UTC).replace(tzinfo=None)
-            upper_bound = dt.replace(hour=23, minute=59, second=59)
-            lower_bound = dt.replace(hour=0, minute=0, second=0)
+            dt = dt.replace(tzinfo=APP_TZ)
+            upper_bound = dt.replace(hour=23, minute=59, second=59).astimezone(
+                UTC).replace(tzinfo=None)
+            lower_bound = dt.replace(hour=0, minute=0, second=0).astimezone(
+                UTC).replace(tzinfo=None)
 
             return query.filter(
                 Message.received >= lower_bound,

--- a/apollo/submissions/filters.py
+++ b/apollo/submissions/filters.py
@@ -262,10 +262,11 @@ class DateFilter(CharFilter):
             except (OverflowError, ValueError):
                 return (None, None)
 
-            dt = dt.replace(tzinfo=APP_TZ).astimezone(
+            dt = dt.replace(tzinfo=APP_TZ)
+            upper_bound = dt.replace(hour=23, minute=59, second=59).astimezone(
                 UTC).replace(tzinfo=None)
-            upper_bound = dt.replace(hour=23, minute=59, second=59)
-            lower_bound = dt.replace(hour=0, minute=0, second=0)
+            lower_bound = dt.replace(hour=0, minute=0, second=0).astimezone(
+                UTC).replace(tzinfo=None)
 
             return (
                 and_(


### PR DESCRIPTION
This PR resolves #594 by properly converting dates from the timezone configured for the application to UTC before using the value to filter records in the database (considering that the database timestamps are stored in UTC).