### PR TITLE
chore: standardize names across participant I/O

### DIFF
--- a/apollo/participants/models.py
+++ b/apollo/participants/models.py
@@ -47,7 +47,7 @@ class ParticipantSet(BaseModel):
             'role': _('Role'),
             'sample': _('Sample'),
             'id': _('Participant ID'),
-            'supervisor': _('Supervisor'),
+            'supervisor': _('Supervisor ID'),
             'phone': _('Phone'),
             'partner': _('Partner'),
             'location': _('Location code'),
@@ -93,7 +93,8 @@ class ParticipantDataField(Resource):
     participant_set = db.relationship(
         'ParticipantSet',
         backref=db.backref(
-            'extra_fields', cascade='all, delete-orphan', passive_deletes=True))
+            'extra_fields', cascade='all, delete-orphan',
+            passive_deletes=True))
 
     def __str__(self):
         return str(

--- a/apollo/participants/services.py
+++ b/apollo/participants/services.py
@@ -36,8 +36,9 @@ class ParticipantService(Service):
 
         # build headers
         headers = [
-            _('ID'), _('Full Name'), _('First Name'), _('Other Names'),
-            _('Last Name'), _('Partner'), _('Role'), _('Location ID')]
+            _('Participant ID'), _('Full Name'), _('First Name'),
+            _('Other Names'), _('Last Name'), _('Partner'), _('Role'),
+            _('Location code')]
         headers.extend(lt.name for lt in location_types)
 
         headers.extend([

--- a/apollo/participants/services.py
+++ b/apollo/participants/services.py
@@ -38,7 +38,7 @@ class ParticipantService(Service):
         headers = [
             _('Participant ID'), _('Full Name'), _('First Name'),
             _('Other Names'), _('Last Name'), _('Partner'), _('Role'),
-            _('Location code')]
+            _('Location Code')]
         headers.extend(lt.name for lt in location_types)
 
         headers.extend([


### PR DESCRIPTION
for both import and exports, the following names are now used:
- "Participant ID" instead of "ID"
- "Location code" instead of "Location ID"
-  "Supervisor ID" instead of "Supervisor"